### PR TITLE
feat: accept only whitespace or line start before ticket id #SRE-1148

### DIFF
--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -4,7 +4,7 @@
  * - #CORE-123
  */
 const getTasks = (source) => {
-    const ticketRefRegex = /#(([A-Z]{2,10}-\d+)|(\w{7,10}))/g;
+    const ticketRefRegex = /(?<=\s|^)#(([A-Z]{2,10}-\d+)|(\w{7,10}))/g;
     const ticketIdRegex = /#(?<taskId>([A-Z]{2,10}-\d+)|(\w{7,10}))/;
     const customTicketIdRegex = /#[A-Z]{2,10}-\d+/;
     const ids =

--- a/lib/get-tasks.spec.js
+++ b/lib/get-tasks.spec.js
@@ -32,6 +32,12 @@ const correctSources = [
       { taskId: "SRE-12345", isCustom: true },
       { taskId: "86bwmzcyf", isCustom: false }
     ]
+  ],
+    [
+    "This PR has a newline before ticket id\n#SRE-12345",
+    [
+      { taskId: "SRE-12345", isCustom: true },
+    ]
   ]
 ];
 
@@ -39,6 +45,8 @@ const incorrectSources = [
   "This PR has too short regular ticket reference #20jt",
   "This PR has too short custom ticket reference #C-123",
   "There is no # in this ticket reference CORE-123",
+  "Regular ticket reference is blended with the text#86bwmzcyf",
+  "Custom ticket reference is blended with the text#BUNNNY-1",
 ];
 
 const emptySource = "A PR without ticket references";


### PR DESCRIPTION
fixes issue with links that contain hashes, tested [here](https://github.com/RampNetwork/ngdp-dbt/pull/562)