### PR TITLE
feat: join PR title and body with space

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -74,7 +74,7 @@ const parallelRequests = (tasks = [], req) => {
 };
 
 const checkAndUpdateClickupIssues = () => {
-  const source = [danger.github.pr.title, danger.github.pr.body].join();
+  const source = [danger.github.pr.title, danger.github.pr.body].join(' ');
   const tasks = getTasks(source);
 
   if (tasks.length === 0) {


### PR DESCRIPTION
Join PR title and body with a space in-between. Lack of space caused the title to be blended with the description thus ticket name was not detected properly.