### PR TITLE
fix: [#SRE-1865] clicop tries to check all clickup-like tickets, but considers only valid ones for the CI check

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -28,8 +28,7 @@ const getClickupTicketName = async (taskId, isCustom) => {
     resource,
     method: 'GET',
   });
-  const name = response?.data?.name ?? undefined
-  return name
+  return response?.data?.name ?? undefined
 }
 
 const getTaskResource = ({ taskId, isCustom }, field = '') => {


### PR DESCRIPTION
# Changes
- axios error handling only displays failed request url instead of full error, it compacts the error message, and clearly shows which request (ticketid) failed
- only validated tickets array (tasksWithName) is considered for the CI check, instead of everything that looks like a ticket (tasks array)

# QA
- create a draft PR in ramp-instant, go to .github/workflows/clicop.yml, change clicop job to use this branch
` - uses: RampNetwork/clicop@fix/clicop`
- add to PR description invalid clickup id's 
- add to PR description valid clickup id's

Closes: #SRE-1865