### PR TITLE
feat: migrate logic from ClickUp to Jira #PLTM-233

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 ![CliCop logo](clicop.png)
 
 
-CliCop is an Github Actions action that enforces pinning ClickUp ticket id reference in a PR.\
-I will fail if there is no task id in PR title or body.\
-It does not yet check if the task really exists in ClickUp.\
+CliCop is an Github Actions action that enforces pinning ticket id reference in a PR.\
+It will fail if there is no task id in PR title.\
 It utilizes [DangerJS](https://danger.systems/js/) to perform the check.
 
 ## Inputs
 github_token - Github authentification token.
-clickup_token - ClickUp authentification token.
+jira_token - Jira authentification token.
 
 ## Testing
 The action conitains some unit tests. To run them:
@@ -42,5 +41,5 @@ jobs:
       - uses: RampNetwork/github-actions/clicop@clicop-v1.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }} # this is passed automatically https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-          clickup_token: ${{ secrets.CLICKUP_TOKEN }}
+          jira_token: ${{ secrets.JIRA_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,12 @@
 name: CliCop
-description: "Run DangerJS to check if the PR is has a valid Clickup ticket reference"
+description: "Run DangerJS to check if the PR is has a valid Jira ticket reference"
 
 inputs:
   github_token:
     description: "Github authentification token"
+    required: true
+  jira_token:
+    description: "Jira authentification token"
     required: true
 
 runs:
@@ -20,5 +23,6 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        JIRA_TOKEN: ${{ inputs.jira_token }}
         NODE_PATH: ${{ github.action_path }}
       run: npx danger -i CliCop --dangerfile ${{ github.action_path }}/dangerfile.js ci

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   jira_token:
     description: "Jira authentification token"
     required: true
+  jira_token_user:
+    description: "User email of Jira user the jira_token belongs to"
+    required: true
 
 runs:
   using: composite
@@ -24,5 +27,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         JIRA_TOKEN: ${{ inputs.jira_token }}
+        JIRA_TOKEN_USER: ${{ inputs.jira_token_user }}
         NODE_PATH: ${{ github.action_path }}
       run: npx danger -i CliCop --dangerfile ${{ github.action_path }}/dangerfile.js ci

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,6 @@ inputs:
   github_token:
     description: "Github authentification token"
     required: true
-  clickup_token:
-    description: "Clickup authentification token"
-    required: true
 
 runs:
   using: composite
@@ -23,6 +20,5 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-        CLICKUP_TOKEN: ${{ inputs.clickup_token }}
         NODE_PATH: ${{ github.action_path }}
       run: npx danger -i CliCop --dangerfile ${{ github.action_path }}/dangerfile.js ci

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -11,9 +11,9 @@ const jiraRequest = async ({ resource, method = 'GET', data = {} }) =>
     method,
     url: resource,
     baseURL: JIRA_API_URL,
-    headers: {
-      Authorization: `Basic ${Buffer.from(`${JIRA_TOKEN_USER}:${process.env.JIRA_TOKEN}`)}`,
-      'Content-Type': 'application/json',
+    auth: {
+      username: JIRA_TOKEN_USER,
+      password: process.env.JIRA_TOKEN,
     },
     data,
   }).catch(error => {
@@ -27,7 +27,7 @@ const getJiraIssueName = async (issueId) => {
     resource,
     method: 'GET',
   });
-  return response?.data?.name ?? undefined
+  return response?.data?.fields?.summary ?? undefined
 }
 
 const parallelRequests = (tasks = [], req) => {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 const getTasks = require('./lib/get-tasks.js');
 
 const JIRA_BASE_URL = 'https://rampnetwork.atlassian.net';
-const JIRA_API_URL = `${JIRA_URL}/rest/api/2`;
+const JIRA_API_URL = `${JIRA_BASE_URL}/rest/api/2`;
 const JIRA_TOKEN_USER = 'michal.jasiorowski@ramp.network'
 
 const jiraRequest = async ({ resource, method = 'GET', data = {} }) =>

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -39,7 +39,7 @@ const parallelRequests = (tasks = [], req) => {
 };
 
 const checkTasks = async () => {
-  const source = [danger.github.pr.title].join(' ');
+  const source = danger.github.pr.title;
   const tasks = getTasks(source);
   const allTasks = await parallelRequests(tasks, async ({ taskId }) => {
     return {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -39,7 +39,7 @@ const parallelRequests = (tasks = [], req) => {
 };
 
 const checkTasks = async () => {
-  const source = [danger.github.pr.title, danger.github.pr.body].join(' ');
+  const source = [danger.github.pr.title].join(' ');
   const tasks = getTasks(source);
   const allTasks = await parallelRequests(tasks, async ({ taskId }) => {
     return {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -44,7 +44,7 @@ const checkTasks = async () => {
   const allTasks = await parallelRequests(tasks, async ({ taskId }) => {
     return {
       taskId: taskId,
-      name: getJiraIssueName(taskId),
+      name: await getJiraIssueName(taskId),
     }
   });
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -51,12 +51,12 @@ const checkTasks = async () => {
   const tasksWithName = allTasks.filter(({ name }) => name);
   if (tasksWithName.length === 0) {
     fail(
-      '<b>Please add the Jira issue key to the PR e.g.: #DATA-98</b>\n' +
+      '<b>Please add the Jira issue key to the PR title e.g.: #DATA-98</b>\n' +
 
       '(remember to add hash)\n\n' +
       '<i>You can find issue key eg. in the last part of URL when issue is viewed in the browser eg.:\n' +
-      `URL: ${JIRA_BASE_URL}/browse/DATA-98 -> issue key: DATA-98 -> what should be added to PR: #DATA-98\n\n` +
-      'You can add more than one issue key in the PR title or/and description.</i>'
+      `URL: ${JIRA_BASE_URL}/browse/DATA-98 -> issue key: DATA-98 -> what should be added to the PR title: #DATA-98\n\n` +
+      'You can add more than one issue key in the PR title.</i>'
     );
     return;
   }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -51,9 +51,7 @@ const checkTasks = async () => {
   const tasksWithName = allTasks.filter(({ name }) => name);
   if (tasksWithName.length === 0) {
     fail(
-      '<b>Please add the Jira issue key to the PR title e.g.: #DATA-98</b>\n' +
-
-      '(remember to add hash)\n\n' +
+      '<b>Please add the Jira issue key at the end of PR title e.g.: #DATA-98</b> (remember to add hash)\n\n' +
       '<i>You can find issue key eg. in the last part of URL when issue is viewed in the browser eg.:\n' +
       `URL: ${JIRA_BASE_URL}/browse/DATA-98 -> issue key: DATA-98 -> what should be added to the PR title: #DATA-98\n\n` +
       'You can add more than one issue key in the PR title.</i>'

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -4,7 +4,6 @@ const getTasks = require('./lib/get-tasks.js');
 
 const JIRA_BASE_URL = 'https://rampnetwork.atlassian.net';
 const JIRA_API_URL = `${JIRA_BASE_URL}/rest/api/2`;
-const JIRA_TOKEN_USER = 'michal.jasiorowski@ramp.network'
 
 const jiraRequest = async ({ resource, method = 'GET', data = {} }) =>
   axios({
@@ -12,7 +11,7 @@ const jiraRequest = async ({ resource, method = 'GET', data = {} }) =>
     url: resource,
     baseURL: JIRA_API_URL,
     auth: {
-      username: JIRA_TOKEN_USER,
+      username: process.env.JIRA_TOKEN_USER,
       password: process.env.JIRA_TOKEN,
     },
     data,

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -5,13 +5,20 @@
 const getTasks = (source) => {
   const taskRefRegex = /(?<=\s|^)#[A-Z]{2,10}-\d+/g;
   const refs = source.match(taskRefRegex) || [];
+  const uniqueRefs = new Set(refs);
 
   let tasks = [];
-  for (const ref of refs) {
+  for (const ref of uniqueRefs) {
     tasks.push({
       taskId: ref.slice(1), // remove # from the beginning of the reference
     });
   }
+  // sort tasks alphabetically
+  tasks.sort(function(refA, refB) {
+    if (refA.taskId < refB.taskId) return -1;
+    if (refA.taskId > refB.taskId) return 1;
+    return 0;
+  });
   return tasks;
 };
 

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -13,12 +13,6 @@ const getTasks = (source) => {
       taskId: ref.slice(1), // remove # from the beginning of the reference
     });
   }
-  // sort tasks alphabetically
-  tasks.sort(function(refA, refB) {
-    if (refA.taskId < refB.taskId) return -1;
-    if (refA.taskId > refB.taskId) return 1;
-    return 0;
-  });
   return tasks;
 };
 

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -1,27 +1,18 @@
 /**
  * Acceptable formats:
- * - #20jt35r
  * - #CORE-123
  */
 const getTasks = (source) => {
-    const ticketRefRegex = /(?<=\s|^)#(([A-Z]{2,10}-\d+)|(\w{7,10}))/g;
-    const ticketIdRegex = /#(?<taskId>([A-Z]{2,10}-\d+)|(\w{7,10}))/;
-    const customTicketIdRegex = /#[A-Z]{2,10}-\d+/;
-    const ids =
-      source.match(ticketRefRegex)?.map(v => ({
-        ...v.match(ticketIdRegex).groups,
-        isCustom: customTicketIdRegex.test(v),
-      })) || [];
+  const taskRefRegex = /(?<=\s|^)#[A-Z]{2,10}-\d+/g;
+  const refs = source.match(taskRefRegex) || [];
 
-    return Object.values(
-      ids.reduce(
-        (tasks, task) => ({
-          ...tasks,
-          [task.taskId]: task,
-        }),
-        {}
-      )
-    );
-  };
+  let tasks = [];
+  for (const ref of refs) {
+    tasks.push({
+      taskId: ref.slice(1), // remove # from the beginning of the reference
+    });
+  }
+  return tasks;
+};
 
 module.exports = getTasks;

--- a/lib/get-tasks.js
+++ b/lib/get-tasks.js
@@ -3,14 +3,18 @@
  * - #CORE-123
  */
 const getTasks = (source) => {
-  const taskRefRegex = /(?<=\s|^)#[A-Z]{2,10}-\d+/g;
-  const refs = source.match(taskRefRegex) || [];
+  // Matches the prefix of the string containg only issue references delimited with whitespaces
+  const prefixWithRefsRegex = /((\s+|^)#[A-Z]{2,10}-\d+)+$/;
+  const [prefix] = source.match(prefixWithRefsRegex) || [''];
+  // Picks individual issue references from the string
+  const taskRefRegex = /(?<=(\s|^)#)[A-Z]{2,10}-\d+/g;
+  const refs = prefix.match(taskRefRegex) || [];
   const uniqueRefs = new Set(refs);
 
   let tasks = [];
   for (const ref of uniqueRefs) {
     tasks.push({
-      taskId: ref.slice(1), // remove # from the beginning of the reference
+      taskId: ref,
     });
   }
   return tasks;

--- a/lib/get-tasks.spec.js
+++ b/lib/get-tasks.spec.js
@@ -2,16 +2,29 @@ const getTasks = require('./get-tasks.js');
 
 const correctSources = [
   [
-    "This PR closes #BUNNNY-1",
+    "This PR closes #BUNNY-1",
     [
-      { taskId: "BUNNNY-1" }
+      { taskId: "BUNNY-1" }
+    ]
+  ],
+  [
+    "This PR has duplicated reference #BUNNY-1 #BUNNY-1",
+    [
+      { taskId: "BUNNY-1" },
     ]
   ],
   [
     "This PR closes #CORE-123 and is related to #BUNNY-1",
     [
-      { taskId: "CORE-123" },
-      { taskId: "BUNNY-1" }
+      { taskId: "BUNNY-1" },
+      { taskId: "CORE-123" }
+    ]
+  ],
+  [
+    "This PR closes #BUNNY-1 and is related to #CORE-123",
+    [
+      { taskId: "BUNNY-1" },
+      { taskId: "CORE-123" }
     ]
   ],
   [
@@ -25,8 +38,8 @@ const correctSources = [
 const incorrectSources = [
   "This PR has too short custom ticket reference #C-123",
   "There is no # in this ticket reference CORE-123",
-  "Ticket reference is blended with the text#BUNNNY-1",
-  "Ticket reference has doubled # sign ##BUNNNY-1",
+  "Ticket reference is blended with the text#BUNNY-1",
+  "Ticket reference has doubled # sign ##BUNNY-1",
 ];
 
 const emptySource = "A PR without ticket references";

--- a/lib/get-tasks.spec.js
+++ b/lib/get-tasks.spec.js
@@ -4,49 +4,29 @@ const correctSources = [
   [
     "This PR closes #BUNNNY-1",
     [
-      { taskId: "BUNNNY-1", isCustom: true }
+      { taskId: "BUNNNY-1" }
     ]
   ],
   [
-    "This PR closes #86bwmzcyf",
+    "This PR closes #CORE-123 and is related to #BUNNY-1",
     [
-      { taskId: "86bwmzcyf", isCustom: false }
+      { taskId: "CORE-123" },
+      { taskId: "BUNNY-1" }
     ]
   ],
   [
-    "This PR closes #86bwmzcyf but it's in the middle of the text",
-    [
-      { taskId: "86bwmzcyf", isCustom: false }
-    ]
-  ],
-  [
-    "This PR closes #CORE-123 and is related to #20jt35r",
-    [
-      { taskId: "CORE-123", isCustom: true },
-      { taskId: "20jt35r", isCustom: false }
-    ]
-  ],
-  [
-    "This PR closes #SRE-12345 and is related to #86bwmzcyf",
-    [
-      { taskId: "SRE-12345", isCustom: true },
-      { taskId: "86bwmzcyf", isCustom: false }
-    ]
-  ],
-    [
     "This PR has a newline before ticket id\n#SRE-12345",
     [
-      { taskId: "SRE-12345", isCustom: true },
+      { taskId: "SRE-12345" },
     ]
   ]
 ];
 
 const incorrectSources = [
-  "This PR has too short regular ticket reference #20jt",
   "This PR has too short custom ticket reference #C-123",
   "There is no # in this ticket reference CORE-123",
-  "Regular ticket reference is blended with the text#86bwmzcyf",
-  "Custom ticket reference is blended with the text#BUNNNY-1",
+  "Ticket reference is blended with the text#BUNNNY-1",
+  "Ticket reference has doubled # sign ##BUNNNY-1",
 ];
 
 const emptySource = "A PR without ticket references";

--- a/lib/get-tasks.spec.js
+++ b/lib/get-tasks.spec.js
@@ -14,25 +14,25 @@ const correctSources = [
     ]
   ],
   [
-    "This PR closes #CORE-123 and is related to #BUNNY-1",
+    "This PR closes #CORE-123 but the reference is not at the end of the title #BUNNY-1",
     [
       { taskId: "BUNNY-1" },
-      { taskId: "CORE-123" }
     ]
   ],
   [
-    "This PR closes #BUNNY-1 and is related to #CORE-123",
+    "This PR closes two issues #CORE-123 #BUNNY-1",
     [
+      { taskId: "CORE-123" },
       { taskId: "BUNNY-1" },
-      { taskId: "CORE-123" }
     ]
   ],
   [
-    "This PR has a newline before ticket id\n#SRE-12345",
+    "This PR closes two issues #CORE-123   #BUNNY-1",
     [
-      { taskId: "SRE-12345" },
+      { taskId: "CORE-123" },
+      { taskId: "BUNNY-1" },
     ]
-  ]
+  ],
 ];
 
 const incorrectSources = [
@@ -40,6 +40,7 @@ const incorrectSources = [
   "There is no # in this ticket reference CORE-123",
   "Ticket reference is blended with the text#BUNNY-1",
   "Ticket reference has doubled # sign ##BUNNY-1",
+  "Ticket reference #BUNNY-1 is in the middle of the title",
 ];
 
 const emptySource = "A PR without ticket references";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clicop",
   "version": "1.0.0",
-  "description": "Action that enforces pinning ClickUp ticket id reference in a PR using DangerJS",
+  "description": "Action that enforces pinning Jira ticket id reference in a PR using DangerJS",
   "main": "dangerfile.js",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
## Changes

- enhance parsing of task references
  - use simpler, iterative implementation
  - remove parsing ClickUp's custom task ids (`#20jt35r`-like)
- remove for ClickUp tickets
- add logic for Jira issues
  - fetch issue existence and its name from Jira REST API

## Testing

Tested on two PRs https://github.com/RampNetwork/ramp-infra/pull/779 and https://github.com/RampNetwork/ramp-instant/pull/20764. For both Jira references were detected correctly.